### PR TITLE
Updates on API Management and the "Forwarded" extra header.

### DIFF
--- a/api-management.md
+++ b/api-management.md
@@ -1,21 +1,105 @@
 ## API Management
 
-This is work in process.
+### API Management Scenarios
 
-### The `X-Api-Host` header
+There are many different scenarions in which API management can and must be used. The following sections describe the four most basic scenarios.
 
-Whenever the API Gateway makes a call to a backend API service, it MUST add a `X-Api-Host` custom header to the call. This header is needed to correctly assemble [hypermedia](response-format.md) links wherever absolute URIs are needed.
+#### Internal API Use
 
-See also [Hypermedia and REST](hypermedia-and-rest.md) for a discussion of this custom header.
+#### Protected API Use (Partner use)
+
+#### Public API Use
+
+#### Mobile APIs
+
+
+### API Gateways and Portals
+
+APIs can and should be grouped in functionality groups, which in turn can be managed via one API Management instance. Please note that it is not prescribed which technical solution has to be used, but this is rather decided from case to case.
+
+Nonetheless, the introduction of a new API management solution has to be discussed with the CTO office/the Architecture Review Board (ARB).
+
+In any case it is encouraged that also the API management solution, or at least, the API contained in the APIm solution, has to be maintained and operated (in the DevOps sense) by the team which operates and maintains the underlying service. The API inside the API management solution is to be treated **as a part of the service itself, it is not an addon**.
+
+At Haufe, we have a couple of predefined API management solutions (API gateway plus API developer portal), which all follow a simple naming schema:
+
+* `<topic hub>.haufe.io` points to the developer portal of a topic's API management solution. This is the URL the developers will use at design time of the consuming application
+* `api.<topic hub>.haufe.io` points to the API gateway of the topic's API management solution. This is the URL the consuming clients will use at runtime.
+
+Any new API mamagement solution should adher to this naming schema, wherever technically feasible and and wherever it makes sense (exceptions are to be discussed).
+
+#### Meta portal `apis.haufe.io`
+
+(TBD, this is a suggestion, the API meta portal is not yet available)
+
+In order to make all Haufe APIs searchable and discoverable, they have to be registered with the [`apis.haufe.io`](https://apis.haufe.io) search service.
+
+The portal at `apis.haufe.io` does not provide any means of subscribing to an API, but just makes sure the APIs which can be located at various API portals (or just inside API gateways as may be the case for internal services) can be found and evaluated for their fitness for a specific purpose.
+
+In order to achieve this kind of discoverability, it is mandatory for an API managed API to be registered with this API meta portal using its Swagger representation. **Swagge 2.0/OpenAPI is the minimum API documentation format**; a Swagger definition **must** be present, all other information which can and will be defined for an API is optional in terms of discoverability.
+
+#### `haufe.io` Certificates
+
+For the `*.haufe.io` domain, there exists a wildcard certificate which can be used for the developer portals.
+
+For `api.<topic hub.haufe.io` DNS entries, specific certificates have to purchased (via IT ticket). Currently, we do not have an automated process for this, but in those cases where the API gateway is operated by ourselves, setting up [Let's Encrypt](https://letsencrypt.org) is a viable solution which is encouraged, wherever it is feasible.
+
+#### Service Hub
+
+The Service hub is located at the following URLs:
+
+* Developer Portal: [`https://servicehub.haufe.io`](https://servicehub.haufe.io)
+
+The API gateway is addressed with `https://api.servicehub.haufe.io`, which is also documented when opening the portal.
+
+The Service Hub is intended for microservices which are not especially bound to a specific domain. Examples of types of services which can be found in the service are:
+
+* Health Insurance public information
+* Bank information (IBAN calculator, BIC directory)
+* ...
+
+Additional services for the service should fall into approximately the same size and topic corridor.
+
+The Service Hub runs using the Azure API Management SaaS solution.
+
+#### SSMP Hub
+
+The SSMP hub contains APIs which are dealing with the Sales, Services and Marketing platform based on Salesforce. In some cases, we need an efficient and stable way of accessing and/or updating data in Salesforce, and those APIs are located inside the SSMPhub API Management portal.
+
+The SSMP hub is located at the following URL:
+
+* [`https://ssmphub.haufe.io`](https://ssmphub.haufe.io)
+
+Likewise, the API gateway (which in turn can be looked up in the API gateway) is located at the URL `https://api.ssmphub.haufe.io`.
+
+The SSMP Hub runs using the Azure API Management SaaS solution.
+
+#### Content Hub
+
+The Content Hub contains all APIs which are content related: Ingestion of new content, search and retrieval of content. The APIs which are content related are located at the following location:
+
+* [`https://contenthub.haufe.io`](https://contenthub.haufe.io)
+
+Likewise, the API gateway (which in turn can be looked up in the API gateway) is located at the URL `https://api.ssmphub.haufe.io`.
+
+As the Service Hub and the SSMP Hub, additional content driven services may be subject to grouping inside the Content Hub API Management solution.
+
+The Content Hub runs using the Azure API Management SaaS solution.
+
+### The `Forwarded` header
+
+Whenever the API Gateway makes a call to a backend API service, it MUST add a `Forwarded` header (see [RFC 7239](https://tools.ietf.org/html/rfc7239)), which contains the "front end" visible host and URL data which can subsequently be used to assemble [hypermedia](response-format.md) links.
+
+See also [Hypermedia and REST](hypermedia-and-rest.md) for a discussion of this header.
 
 #### Implementation in Azure API Management
 
-By applying a custom policy on the Product level, you can insert this header automatically:
+By applying a custom policy on the Product or even Tenant level, you can insert this header automatically:
 
-```xml
+```
 <inbound>
-	<set-header name="X-Api-Host" exists-action="override">
-		<value>@(context.Request.OriginalUrl.Scheme + "://" + context.Request.OriginalUrl.Host + context.Api.Path)</value>
+	<set-header name="Forwarded" exists-action="override">
+		<value>@("proto=" + context.Request.OriginalUrl.Scheme + ";host=" + context.Request.OriginalUrl.Host + ";prefix=" + context.Api.Path)</value>
 	</set-header>
 	<base />
 </inbound>
@@ -24,5 +108,40 @@ By applying a custom policy on the Product level, you can insert this header aut
 Example: Your end point is called at `https://api.contenthub.haufe.de/search/v1/query?q=Steuerhinterziehung`. The API prefix is `/search/v1`, and the operation is `/query`. In this case, the header will look as follows:
 
 ```
-X-Api-Host: https://api.contenthub.haufe.de/search/v1
+Forwarded: proto=https;host=api.contenthub.haufe.de;prefix=/search/v1
 ```
+
+The use of `port=` is optional, but MUST be used in case the port is not the standard `443` port. The port MUST NOT be part of the `host=` statement.
+
+#### Implementation using the wicked API Portal
+
+In `config.json` of an API:
+
+```
+  "plugins": [
+      {
+          "name":"request-transformer",
+          "config":{
+              "add": {
+                  "headers": [
+                      "%%Forwarded"
+                  ]
+              }
+          }
+      }
+  ]
+```
+
+The special string `%%Forwarded` will dynamically be replaced with a suitable `Forwarded: ...` header for the specific API, API Host and schema.
+
+### Automating API deployments
+
+As an integral part of a web (http(s) based) service, the API Management bits and pieces also need to be a part of the deployment process.
+
+#### Blue/Green Deployment - Backend Service Level
+
+tbd.
+
+#### Blue/Green Deployment - API Management Level
+
+tbd.

--- a/hypermedia-and-rest.md
+++ b/hypermedia-and-rest.md
@@ -35,12 +35,17 @@ The reason is mostly for ease of use by the client, so that it never has to find
 
 In [Hypermedia responses](response-format.md), we require the use of absolute URLs (as stated in the above section). If your API lives behind an [API Management](api-management.md), the actual URI of the (backend) API will be different from the URI which is the one to call, i.e. the one of the API management gateway.
 
-As a rule, the API Management gateway MUST pass an additional header with the call to the backend API containing the API Gateway base URL for the API at hand. This header must be named `X-Api-Host`.
+As a rule, the API Management gateway MUST pass an additional header with the call to the backend API containing the API Gateway base URL for the API at hand. This header must be named `Forwarded`, as described in [RFC 7239](https://tools.ietf.org/html/rfc7239). The two parameters `host` and `proto` are pre-defined in the RFC, whereas we need additional ones, which is explicitly allowed per Section 5.5 of the RFC:
 
-Example:
+* `host`: Must contain the host name of the API Gateway; this is the host an API client uses to actually talk to the API.
+* `proto`: The protocol/schema to use. This MUST be `https` for all of our APIs (see [security and authentication](security-and-authentication.md))
+* Extension `port`: OPTIONAL - The port of the API Gateway. Usually this can be assumed to be `443` if `proto` equals `https`; use if deviating
+* Extension `prefix`: The base path of the API on the API Gateway, e.g. `/someapi/v1`. 
+
+**Example**: A request goes to `https://api.contenthub.haufe.io/ingest/v1/bulk/63874638746834`, which is forwarded to the ingest service in the backend. The API Gateway must pass on this information in the following way:
 
 ```
-X-Api-Host: https://api.contenthub.haufe.de/ingest/v1
+Forwarded: proto=https;host=api.contenthub.haufe.io;port=443;prefix=/ingest/v1
 ```
 
 If present, this header MUST be used to assemble hypermedia links in responses, so that an API consumer is directed to the right place.

--- a/security-and-authentication.md
+++ b/security-and-authentication.md
@@ -8,7 +8,7 @@ Above all, OAuth 2.0 will mean improved security and better end-user and consume
 
 Don't do something *like* OAuth, but different. It will be frustrating for app developers if they can't use an OAuth library in their language because of your variation.
 
-###SSL everywhere - all the time
+### SSL everywhere - all the time
 
 Always use SSL.  No exceptions.  Today, your web APIs can get accessed from anywhere there is internet (like libraries, coffee shops, airports among others).  Not all of these are secure. Many don't encrypt communications at all, allowing for easy eavesdropping or impersonation if authentication credentials are hijacked.
 


### PR DESCRIPTION
Removed the `X-ApiHost` header and put in the standard `Forwarded` header. Some prose on API Management in Haufe.
